### PR TITLE
this is what happens when you use addrs.NoKey in a map

### DIFF
--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -1114,7 +1114,7 @@ func (c *Config) transformOverriddenResourcesForTest(run *TestRun, file *TestFil
 		res.IsOverridden = true
 		switch key := overrideRes.TargetParsed.Resource.Key; key {
 		case nil:
-			res.DefaultOverrideValues = overrideRes.Values
+			res.OverrideValues[addrs.NoKey] = overrideRes.Values
 		default:
 			if res.OverrideValues == nil {
 				res.OverrideValues = make(map[addrs.InstanceKey]map[string]cty.Value)
@@ -1137,7 +1137,6 @@ func (c *Config) transformOverriddenResourcesForTest(run *TestRun, file *TestFil
 			}
 
 			res.IsOverridden = false
-			res.DefaultOverrideValues = nil
 			res.OverrideValues = make(map[addrs.InstanceKey]map[string]cty.Value)
 		}
 	}, diags

--- a/internal/configs/config.go
+++ b/internal/configs/config.go
@@ -1112,15 +1112,10 @@ func (c *Config) transformOverriddenResourcesForTest(run *TestRun, file *TestFil
 		}
 
 		res.IsOverridden = true
-		switch key := overrideRes.TargetParsed.Resource.Key; key {
-		case nil:
-			res.OverrideValues[addrs.NoKey] = overrideRes.Values
-		default:
-			if res.OverrideValues == nil {
-				res.OverrideValues = make(map[addrs.InstanceKey]map[string]cty.Value)
-			}
-			res.OverrideValues[key] = overrideRes.Values
+		if res.OverrideValues == nil {
+			res.OverrideValues = make(map[addrs.InstanceKey]map[string]cty.Value)
 		}
+		res.OverrideValues[overrideRes.TargetParsed.Resource.Key] = overrideRes.Values
 	}
 
 	return func() {

--- a/internal/configs/resource.go
+++ b/internal/configs/resource.go
@@ -58,7 +58,7 @@ type Resource struct {
 	// DefaultOverrideValues are only valid if IsOverridden is set to true. The values
 	// should be used to compose mock provider response. It is possible to have
 	// zero-length DefaultOverrideValues even if IsOverridden is set to true.
-	DefaultOverrideValues map[string]cty.Value
+	// DefaultOverrideValues map[string]cty.Value
 	// OverrideValues are only valid if IsOverridden is set to true. The values
 	// should be used to compose mock provider response. It is possible to have
 	// zero-length OverrideValues even if IsOverridden is set to true. Unlike

--- a/internal/tofu/node_resource_abstract_instance.go
+++ b/internal/tofu/node_resource_abstract_instance.go
@@ -3017,7 +3017,7 @@ func (n *NodeAbstractResourceInstance) getProvider(ctx context.Context, evalCtx 
 	}
 
 	provider = provider.
-		withOverrideResource(n.Addr, n.Config.OverrideValues, n.Config.DefaultOverrideValues).
+		withOverrideResource(n.Addr, n.Config.OverrideValues).
 		linkWithCurrentResource(n.Addr)
 
 	return provider, schema, nil

--- a/internal/tofu/provider_for_test_framework.go
+++ b/internal/tofu/provider_for_test_framework.go
@@ -249,7 +249,7 @@ func (p providerForTest) withOverrideResource(addr addrs.AbsResourceInstance, ov
 		panic("BUG: unsupported override resource mode: " + addr.Resource.Resource.Mode.String())
 	}
 	key := addr.Resource.Key
-	if vals, ok := overrides[key]; key != nil && ok {
+	if vals, ok := overrides[key]; ok {
 		resources[addr.String()] = resourceForTest{
 			values: vals,
 		}

--- a/internal/tofu/provider_for_test_framework.go
+++ b/internal/tofu/provider_for_test_framework.go
@@ -228,13 +228,14 @@ func (p providerForTest) withOverrideResources(overrideResources []*configs.Over
 	// make an empty, unused map; we use the "defaultOverrides" to set the value of this overriding resource
 	overrides := make(map[addrs.InstanceKey]map[string]cty.Value)
 	for _, res := range overrideResources {
-		p = p.withOverrideResource(*res.TargetParsed, overrides, res.Values)
+		overrides[addrs.NoKey] = res.Values
+		p = p.withOverrideResource(*res.TargetParsed, overrides)
 	}
 
 	return p
 }
 
-func (p providerForTest) withOverrideResource(addr addrs.AbsResourceInstance, overrides map[addrs.InstanceKey]map[string]cty.Value, defaultOverrides map[string]cty.Value) providerForTest {
+func (p providerForTest) withOverrideResource(addr addrs.AbsResourceInstance, overrides map[addrs.InstanceKey]map[string]cty.Value) providerForTest {
 	var resources map[string]resourceForTest
 
 	switch addr.Resource.Resource.Mode {
@@ -254,7 +255,7 @@ func (p providerForTest) withOverrideResource(addr addrs.AbsResourceInstance, ov
 		}
 	} else {
 		resources[addr.String()] = resourceForTest{
-			values: defaultOverrides,
+			values: overrides[addrs.NoKey],
 		}
 	}
 


### PR DESCRIPTION
When I run the test TestTest_InstanceOverride, this is what happens.

```
Running tool: /Users/laurencebordowitz/.goenv/versions/1.25.2/bin/go test -timeout 300s -run ^TestTest_InstanceOverride$ github.com/opentofu/opentofu/internal/command

=== RUN   TestTest_InstanceOverride
=== RUN   TestTest_InstanceOverride/default

!!!!!!!!!!!!!!!!!!!!!!!!!!! OPENTOFU CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

OpenTofu crashed! This is always indicative of a bug within OpenTofu.
Please report the crash with OpenTofu[1] so that we can fix this.

When reporting bugs, please include your OpenTofu version, the stack trace
shown below, and any additional information which may help replicate the issue.

[1]: https://github.com/opentofu/opentofu/issues

!!!!!!!!!!!!!!!!!!!!!!!!!!! OPENTOFU CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

assignment to entry in nil map
goroutine 51 [running]:
runtime/debug.Stack()
        /Users/laurencebordowitz/go/1.25.2/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.3.darwin-arm64/src/runtime/debug/stack.go:26 +0x64
runtime/debug.PrintStack()
        /Users/laurencebordowitz/go/1.25.2/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.3.darwin-arm64/src/runtime/debug/stack.go:18 +0x1c
github.com/opentofu/opentofu/internal/logging.panicHandler({0x1061b12c0, 0x108937290}, {0x14000421000, 0x405, 0x800})
        /Users/laurencebordowitz/code/opentofu/internal/logging/panic.go:96 +0xb4
github.com/opentofu/opentofu/internal/command.(*TestCommand).Run.PanicHandlerWithTraceFn.func4()
        /Users/laurencebordowitz/code/opentofu/internal/logging/panic.go:82 +0x84
panic({0x1061b12c0?, 0x108937290?})
        /Users/laurencebordowitz/go/1.25.2/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.3.darwin-arm64/src/runtime/panic.go:783 +0x120
github.com/opentofu/opentofu/internal/configs.(*Config).transformOverriddenResourcesForTest(0x140001e5180, 0x14000906600, 0x1?)
        /Users/laurencebordowitz/code/opentofu/internal/configs/config.go:1117 +0x524
github.com/opentofu/opentofu/internal/configs.(*Config).TransformForTest(0x0?, 0x14000906600, 0x14000502280, 0x14000841bd8?)
        /Users/laurencebordowitz/code/opentofu/internal/configs/config.go:902 +0xf8
github.com/opentofu/opentofu/internal/command.(*TestFileRunner).ExecuteTestRun(0x14000841e10, {0x10690ab28, 0x108a76180}, 0x140003a8730, 0x140003a8910, 0x140007a69b0, 0x140001e5180)
        /Users/laurencebordowitz/code/opentofu/internal/command/test.go:557 +0x438
github.com/opentofu/opentofu/internal/command.(*TestFileRunner).ExecuteTestFile(0x14000841e10, {0x10690ab28, 0x108a76180}, 0x140003a8910)
        /Users/laurencebordowitz/code/opentofu/internal/command/test.go:483 +0x3c8
github.com/opentofu/opentofu/internal/command.(*TestSuiteRunner).Start(0x14000466e70, {0x10690ab28, 0x108a76180})
        /Users/laurencebordowitz/code/opentofu/internal/command/test.go:408 +0x190
github.com/opentofu/opentofu/internal/command.(*TestCommand).Run.func2()
        /Users/laurencebordowitz/code/opentofu/internal/command/test.go:302 +0x7c
created by github.com/opentofu/opentofu/internal/command.(*TestCommand).Run in goroutine 15
        /Users/laurencebordowitz/code/opentofu/internal/command/test.go:296 +0xb74
With go-routine called from:
goroutine 15 [running]:
runtime/debug.Stack()
        /Users/laurencebordowitz/go/1.25.2/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.3.darwin-arm64/src/runtime/debug/stack.go:26 +0x64
github.com/opentofu/opentofu/internal/logging.PanicHandlerWithTraceFn(...)
        /Users/laurencebordowitz/code/opentofu/internal/logging/panic.go:72
github.com/opentofu/opentofu/internal/command.(*TestCommand).Run(0x140005f1688, {0x0?, 0x5f?, 0x1400007e7e0?})
        /Users/laurencebordowitz/code/opentofu/internal/command/test.go:295 +0xa9c
github.com/opentofu/opentofu/internal/command.TestTest_InstanceOverride.func1(0x14000582e00)
        /Users/laurencebordowitz/code/opentofu/internal/command/test_test.go:1694 +0x4a0
testing.tRunner(0x14000582e00, 0x140006d5590)
        /Users/laurencebordowitz/go/1.25.2/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.3.darwin-arm64/src/testing/testing.go:1934 +0xc8
created by testing.(*T).Run in goroutine 14
        /Users/laurencebordowitz/go/1.25.2/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.3.darwin-arm64/src/testing/testing.go:1997 +0x364
    /Users/laurencebordowitz/code/opentofu/internal/command/test_test.go:1702: output didn't contain expected string:


        Success! 0 passed, 0 failed.
FAIL    github.com/opentofu/opentofu/internal/command   0.851s
```